### PR TITLE
Fix Protection Level

### DIFF
--- a/KeyApplications/HotKeys/HotKeyManager.cs
+++ b/KeyApplications/HotKeys/HotKeyManager.cs
@@ -18,7 +18,7 @@ namespace KeyBindingServiceMeow.KeyApplications.HotKeys
     /// <summary>
     /// This class manage all the hotkeys for a _player.
     /// </summary>
-    internal class HotKeyManager
+    public class HotKeyManager
     {
         private static readonly List<HotKeyManager> ManagerList = new List<HotKeyManager>();
 


### PR DESCRIPTION
Fixes the protection Level of `HotKeyManager`

![image](https://github.com/user-attachments/assets/46f1925a-9d08-432b-882d-37085ff04737)